### PR TITLE
Correct PHP version requirement definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.0.0",
         "monolog/monolog": "1.*",
         "mashape/unirest-php": "^3.0",
         "vlucas/phpdotenv": "^2.5"


### PR DESCRIPTION
# Changed log
- According to the `PHPUnit` version definition, it defines the `^6.0` version.
This version requires `php-7.0` version at least.
- To be compatible with this version, it should let this `PHP-SDK` requires `7.0` at least :).