### PR TITLE
Package phpunit/php-mock-objects is abandoned.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "vlucas/phpdotenv": "^2.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7",
         "mockery/mockery": "^1.2"
     },
     "license": "MIT",


### PR DESCRIPTION
phpunit update required to update new dependencies for mocking.